### PR TITLE
blueprint: Use new constructor format

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -5,7 +5,9 @@ const { Container, publicInternet, allowTraffic } = require('kelda');
  * traffic from the public internet if they want it to be publicly accessible.
  */
 exports.New = function New(githubOauth, googleJson, slackToken) {
-  const bot = new Container('bot', 'keldaio/bot', {
+  const bot = new Container({
+    name: 'bot',
+    image: 'keldaio/bot',
     env: {
       GITHUB_OAUTH: githubOauth,
       SLACK_TOKEN: slackToken,


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.